### PR TITLE
fix ssh for centos7 container

### DIFF
--- a/docker/boxes/centos7/Dockerfile
+++ b/docker/boxes/centos7/Dockerfile
@@ -25,6 +25,9 @@ RUN systemctl enable sshd
 # Cleanup
 RUN yum clean all
 
+# Allow sshing in
+RUN sed -i 's/^UsePrivilegeSeparation.*/UsePrivilegeSeparation no/' /etc/ssh/sshd_config
+
 # Used by systemd
 VOLUME /sys/fs/cgroup
 


### PR DESCRIPTION
Allows sshing into the centos7 container. Fixes this error (same issue in https://github.com/AerisCloud/ansible-role-test/pull/10#issuecomment-123243910):

```
fatal: [centos-7] => SSH Error: ssh: connect to host 172.17.0.50 port 22: Connection refused
    while connecting to 172.17.0.50:22
It is sometimes useful to re-run the command using -vvvv, which prints SSH debug output to help diagnose the issue.
```
